### PR TITLE
タグ周りの実装

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "react-intersection-observer": "^9.10.3",
         "react-select": "^5.8.0",
         "sass": "^1.77.2",
+        "swr": "^2.2.5",
         "zod": "^3.23.8"
       },
       "devDependencies": {
@@ -19191,6 +19192,18 @@
         "webpack": ">=2"
       }
     },
+    "node_modules/swr": {
+      "version": "2.2.5",
+      "resolved": "https://registry.npmjs.org/swr/-/swr-2.2.5.tgz",
+      "integrity": "sha512-QtxqyclFeAsxEUeZIYmsaQ0UjimSq1RZ9Un7I68/0ClKK/U3LoyQunwkQfJZr2fc22DfIXLNDc2wFyTEikCUpg==",
+      "dependencies": {
+        "client-only": "^0.0.1",
+        "use-sync-external-store": "^1.2.0"
+      },
+      "peerDependencies": {
+        "react": "^16.11.0 || ^17.0.0 || ^18.0.0"
+      }
+    },
     "node_modules/synchronous-promise": {
       "version": "2.0.17",
       "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.17.tgz",
@@ -20345,6 +20358,14 @@
         "@types/react": {
           "optional": true
         }
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.2.2.tgz",
+      "integrity": "sha512-PElTlVMwpblvbNqQ82d2n6RjStvdSoNe9FG28kNfz3WiXilJm4DdNkEzRhCZuIDwY8U08WVihhGR5iRqAwfDiw==",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0"
       }
     },
     "node_modules/util": {

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "react-intersection-observer": "^9.10.3",
     "react-select": "^5.8.0",
     "sass": "^1.77.2",
+    "swr": "^2.2.5",
     "zod": "^3.23.8"
   },
   "devDependencies": {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -26,12 +26,12 @@ type SessionsResponse = {
 
 type TagsResponse = {
   id: number
-  tag_name: string
+  name: string
 }[]
 
 async function getServerSideProps(page: number) {
   const sessionsData = (await axiosClient.get<SessionsResponse>(`sessions?page=${page}`)).data
-  const tagsData = (await axiosClient.get<TagsResponse>('tags')).data
+  const tagsData = (await axiosClient.get<TagsResponse>('tags?count=10')).data
   return { sessionsData, tags: tagsData }
 }
 
@@ -49,7 +49,7 @@ export default async function Home({
         <div className={style['custom-container']}>
           <div className={style['tag-container']}>
             {tags.map((tag) => (
-              <BasicChip key={tag.id} text={tag.tag_name} className='-text-black' />
+              <BasicChip key={tag.id} text={tag.name} className='-text-black' />
             ))}
           </div>
           <Link href={'/session/register'}>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -13,7 +13,7 @@ type SessionsResponse = {
     id: number
     user_name: string
     title: string
-    tags: string[]
+    tags: { id: number; name: string }[]
     content: string
     passion_level: number
     created_at: string

--- a/src/app/session/[session_id]/page.tsx
+++ b/src/app/session/[session_id]/page.tsx
@@ -10,12 +10,13 @@ import utils from '@/styles/utils/index.module.scss'
 import clsx from 'clsx'
 import { BasicButton } from '@/components/Buttons/BasicButton'
 import Link from 'next/link'
+import { BasicChip } from '@/components/Buttons/BasicChip'
 
 type SessionResponse = {
   id: number
   title: string
   user_name: string
-  // tags: string[]
+  tags: { id: number; name: string }[]
   platform: number
   url: string
   passion_level: number
@@ -52,12 +53,13 @@ export default async function SessionDetail({ params }: { params: { session_id: 
 
         <div className={clsx(utils['tow-column-wrapper'], utils['gap-16'])}>
           <div
-            className={clsx(utils['gap-wrapper'], utils['direction-column'], utils['gap-12'])}
+            className={clsx(utils['gap-wrapper'], utils['direction-row'], utils['gap-12'])}
             style={{ width: '100%' }}
           >
             <ContentTitle title='タグ' color={contentColor} />
-            {/* TODO:タグのリレーションを実施次第繋ぎこみ */}
-            {/* <p className={clsx(utils.text, utils['size-large'])}>{session.tags.join(',')}</p> */}
+            {session.tags.map((tag) => (
+              <BasicChip key={tag.id} text={tag.name} className='-text-black' />
+            ))}
           </div>
         </div>
 

--- a/src/app/session/register/page.tsx
+++ b/src/app/session/register/page.tsx
@@ -12,17 +12,8 @@ import { PASSION_OPTIONS, PLATFORM_OPTIONS } from '@/features/common/constant'
 import { TagSelect } from '@/components/Forms/TagSelect'
 import { useRegister } from '@/features/register/hooks/useRegister'
 
-/**
- * @todo 仮のタグオプションなので後で削除する
- */
-const dummyTagOptions = [
-  { value: '1', label: 'もくもく会' },
-  { value: '2', label: '勉強会' },
-  { value: '3', label: 'React' }
-]
-
 export default function SessionRegister() {
-  const { form, onSubmit } = useRegister()
+  const { tagOptions, form, onSubmit } = useRegister()
   const errors = form.formState.errors
   return (
     <form>
@@ -67,7 +58,7 @@ export default function SessionRegister() {
             <TagSelect
               name='tags'
               control={form.control}
-              options={dummyTagOptions}
+              options={tagOptions}
               placeholder='もくもく会'
               message={errors.tags?.message}
               error={'tags' in errors}

--- a/src/components/Cards/SessionCard.tsx
+++ b/src/components/Cards/SessionCard.tsx
@@ -50,7 +50,7 @@ type SessionCardProps = {
   userName?: string | null
   title?: string | null
   created_at?: Date | string
-  tags?: Array<string> | null
+  tags?: { id: number; name: string }[] | null
   content?: string | null
   width?: string
   color?: Color
@@ -81,7 +81,7 @@ export const SessionCard = ({
         {tags ? (
           tags?.map((tag, i) =>
             tag ? (
-              <BasicChip key={i} text={tag} size='small' color={color} />
+              <BasicChip key={i} text={tag.name} size='small' color={color} />
             ) : (
               <BasicChip key={i} text='タグなし' size='small' color={color} />
             )

--- a/src/features/register/api/getTags.ts
+++ b/src/features/register/api/getTags.ts
@@ -1,0 +1,26 @@
+import { axiosClient } from '@/utils/libs/axios'
+
+type Tag = {
+  id: number
+  name: string
+}
+
+export type TagRequest = {
+  count?: number | null
+}
+
+type TagResponse = Tag[]
+
+/**
+ * 施設 法人アカウントの一覧情報を取得する
+ */
+export const useGetTags = () => {
+  const fetcher = async (request: TagRequest) => {
+    const url = `tags?count=${request.count}`
+    const res = await axiosClient.get<TagResponse>(url)
+
+    return res.data
+  }
+
+  return { fetcher }
+}

--- a/src/features/register/hooks/useRegister.tsx
+++ b/src/features/register/hooks/useRegister.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useGetTags } from '@/features/register/api/getTags'
 import {
   RegisterFormType,
   registerDefaultValues,
@@ -7,9 +8,14 @@ import {
 } from '@/features/register/hooks/formSchema'
 import { axiosClient } from '@/utils/libs/axios'
 import { zodResolver } from '@hookform/resolvers/zod'
+import { useMemo } from 'react'
 import { SubmitHandler, useForm } from 'react-hook-form'
+import useSWR from 'swr'
 
 export const useRegister = () => {
+  const { fetcher } = useGetTags()
+  const { data: tagList } = useSWR(`tags`, () => fetcher({ count: 10 }))
+
   const form = useForm<RegisterFormType>({
     mode: 'onChange',
     defaultValues: registerDefaultValues,
@@ -17,11 +23,23 @@ export const useRegister = () => {
     resolver: zodResolver(registerFormType)
   })
 
+  const tagOptions = useMemo(() => {
+    if (!tagList) return []
+
+    return tagList.map((tag) => {
+      return {
+        label: tag.name,
+        value: String(tag.id)
+      }
+    })
+  }, [tagList])
+
   const onSubmit: SubmitHandler<RegisterFormType> = async (formData) => {
+    console.log(formData)
     axiosClient.post('sessions/register', formData).then(() => {
       window.location.href = '/'
     })
   }
 
-  return { form, onSubmit }
+  return { form, onSubmit, tagOptions }
 }

--- a/src/features/register/hooks/useRegister.tsx
+++ b/src/features/register/hooks/useRegister.tsx
@@ -35,8 +35,17 @@ export const useRegister = () => {
   }, [tagList])
 
   const onSubmit: SubmitHandler<RegisterFormType> = async (formData) => {
-    console.log(formData)
-    axiosClient.post('sessions/register', formData).then(() => {
+    const formatData = {
+      ...formData,
+      tags: formData.tags.map((tag) => {
+        return {
+          id: Number(tag.value),
+          name: tag.label
+        }
+      })
+    }
+
+    axiosClient.post('sessions/register', formatData).then(() => {
       window.location.href = '/'
     })
   }

--- a/src/stories/Cards/SessionCard.stories.tsx
+++ b/src/stories/Cards/SessionCard.stories.tsx
@@ -29,7 +29,11 @@ export const RedSessionCard: Story = {
     userName: '田中　ほげ太郎',
     title: 'もくもく会参加メンバー募集',
     content: 'もくもく会参加メンバー募集します。一緒に勉強しましょう！',
-    tags: ['勉強会', 'プログラミング', 'もくもく会'],
+    tags: [
+      { id: 1, name: '勉強会' },
+      { id: 2, name: 'プログラミング' },
+      { id: 3, name: 'もくもく会' }
+    ],
     color: 'error'
   }
 }


### PR DESCRIPTION
- セッション一覧ページのタグ一覧に実データを使用
- セッションカード内のタグに実データを出力できるようにした
- セッション詳細のタグ項目に登録されたタグを出力できるようにした
- セッション登録ページ
   - タグセレクトに登録されたタグの実データを使用できるようにした
   - セッション登録時にタグを登録できるようにした。存在しないタグをが選択された場合はタグの新規作成。