### PR TITLE
セッションを削除できるようにした

### DIFF
--- a/src/app/session/[session_id]/edit/page.tsx
+++ b/src/app/session/[session_id]/edit/page.tsx
@@ -127,18 +127,7 @@ export default function Edit() {
           />
         </div>
 
-        <div className={clsx(utils['center-wrapper'])}>
-          <BasicButton
-            color='success'
-            variant='contained'
-            text='セッションを編集する'
-            width='200px'
-            className='-shadow'
-            onClick={form.handleSubmit(onSubmit)}
-          />
-        </div>
-
-        <div className={clsx(utils['center-wrapper'])}>
+        <div className={clsx(utils['center-wrapper'], utils['gap-40'])}>
           <BasicButton
             color='error'
             variant='contained'
@@ -146,6 +135,14 @@ export default function Edit() {
             width='200px'
             className='-shadow'
             onClick={form.handleSubmit(onDelete)}
+          />
+          <BasicButton
+            color='success'
+            variant='contained'
+            text='セッションを編集する'
+            width='200px'
+            className='-shadow'
+            onClick={form.handleSubmit(onSubmit)}
           />
         </div>
 

--- a/src/app/session/[session_id]/edit/page.tsx
+++ b/src/app/session/[session_id]/edit/page.tsx
@@ -12,7 +12,7 @@ import { TagSelect } from '@/components/Forms/TagSelect'
 import { useEdit } from '@/features/edit/hooks/useEdit'
 
 export default function Edit() {
-  const { form, onSubmit, tagOptions } = useEdit()
+  const { form, onSubmit, onDelete, tagOptions } = useEdit()
   const errors = form.formState.errors
   return (
     <form>
@@ -135,6 +135,17 @@ export default function Edit() {
             width='200px'
             className='-shadow'
             onClick={form.handleSubmit(onSubmit)}
+          />
+        </div>
+
+        <div className={clsx(utils['center-wrapper'])}>
+          <BasicButton
+            color='error'
+            variant='contained'
+            text='セッションを削除する'
+            width='200px'
+            className='-shadow'
+            onClick={form.handleSubmit(onDelete)}
           />
         </div>
 

--- a/src/features/edit/hooks/useEdit.ts
+++ b/src/features/edit/hooks/useEdit.ts
@@ -70,9 +70,16 @@ export const useEdit = () => {
     })
   }
 
+  const onDelete = async (formData: EditFormType) => {
+    axiosClient.post(`sessions/delete/${session_id}`, formData).then(() => {
+      window.location.href = '/'
+    })
+  }
+
   return {
     form,
     onSubmit,
+    onDelete,
     tagOptions
   }
 }


### PR DESCRIPTION
セッション削除機能を作成したが、編集画面でバリデーションスキーマの変更を行うにはユーザーのイベントが必要になってきてしまうので後で見直す必要あり。

今の所セッション詳細画面で編集ボタン・削除ボタンの２つを用意するのが良いかなと考えている。

Issue作成済み。